### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,22 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.3
+        - php: 7.2
         - php: 7.1
         - php: 7.0
         - php: 5.6
         - php: 5.5
+          dist: trusty
         - php: 5.5
+          dist: trusty
           env: SYMFONY_VERSION=2.7.*
         - php: 5.5
+          dist: trusty
           env: SYMFONY_VERSION=2.8.*
         - php: 5.5
-          env: SYMFONY_VERSION=3.0.*
-        - php: hhvm
-          sudo: required
           dist: trusty
-          group: edge
+          env: SYMFONY_VERSION=3.0.*
 
 before_install:
     - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "gpslab/cqrs": "~1.0",
         "gpslab/domain-event": "~1.6",
         "symfony/serializer": "~2.3|~3.0",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/tests/PayloadCommandTest.php
+++ b/tests/PayloadCommandTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Payload\PayloadMessage;
 use GpsLab\Component\Payload\PayloadCommand;
 use GpsLab\Component\Payload\Tests\Fixture\RenameContactCommand;
 use GpsLab\Component\Command\Command;
+use PHPUnit\Framework\TestCase;
 
-class PayloadCommandTest extends \PHPUnit_Framework_TestCase
+class PayloadCommandTest extends TestCase
 {
     public function testSetPayload()
     {

--- a/tests/PayloadDomainEventTest.php
+++ b/tests/PayloadDomainEventTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Payload\PayloadMessage;
 use GpsLab\Component\Payload\PayloadDomainEvent;
 use GpsLab\Component\Payload\Tests\Fixture\RenamedContactEvent;
 use GpsLab\Domain\Event\EventInterface;
+use PHPUnit\Framework\TestCase;
 
-class PayloadDomainEventTest extends \PHPUnit_Framework_TestCase
+class PayloadDomainEventTest extends TestCase
 {
     public function testSetPayload()
     {

--- a/tests/PayloadMessageTest.php
+++ b/tests/PayloadMessageTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Payload\Tests;
 
 use GpsLab\Component\Payload\Tests\Fixture\SomeMessage;
+use PHPUnit\Framework\TestCase;
 
-class PayloadMessageTest extends \PHPUnit_Framework_TestCase
+class PayloadMessageTest extends TestCase
 {
     public function testSetPayload()
     {

--- a/tests/PayloadQueryTest.php
+++ b/tests/PayloadQueryTest.php
@@ -15,8 +15,9 @@ use GpsLab\Component\Payload\PayloadMessage;
 use GpsLab\Component\Payload\PayloadQuery;
 use GpsLab\Component\Payload\Tests\Fixture\ContactByIdentityQuery;
 use GpsLab\Component\Query\Query;
+use PHPUnit\Framework\TestCase;
 
-class PayloadQueryTest extends \PHPUnit_Framework_TestCase
+class PayloadQueryTest extends TestCase
 {
     public function testSetPayload()
     {

--- a/tests/Serializer/MessageTypeResolver/ClassNameMessageTypeResolverTest.php
+++ b/tests/Serializer/MessageTypeResolver/ClassNameMessageTypeResolverTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Payload\Tests\Serializer\MessageTypeResolver;
 use GpsLab\Component\Payload\Payload;
 use GpsLab\Component\Payload\Serializer\MessageTypeResolver\ClassNameMessageTypeResolver;
 use GpsLab\Component\Payload\Tests\Fixture\ContactByIdentityQuery;
+use PHPUnit\Framework\TestCase;
 
-class ClassNameMessageTypeResolverTest extends \PHPUnit_Framework_TestCase
+class ClassNameMessageTypeResolverTest extends TestCase
 {
     /**
      * @var ClassNameMessageTypeResolver

--- a/tests/Serializer/PayloadNormalizerTest.php
+++ b/tests/Serializer/PayloadNormalizerTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Component\Payload\Tests\Serializer;
 use GpsLab\Component\Payload\Payload;
 use GpsLab\Component\Payload\Serializer\PayloadNormalizer;
 use GpsLab\Component\Payload\Tests\Fixture\ContactByIdentityQuery;
+use PHPUnit\Framework\TestCase;
 
-class PayloadNormalizerTest extends \PHPUnit_Framework_TestCase
+class PayloadNormalizerTest extends TestCase
 {
     /**
      * @var PayloadNormalizer

--- a/tests/Serializer/TypedPayloadNormalizerTest.php
+++ b/tests/Serializer/TypedPayloadNormalizerTest.php
@@ -14,8 +14,9 @@ use GpsLab\Component\Payload\Payload;
 use GpsLab\Component\Payload\Serializer\MessageTypeResolver\MessageTypeResolver;
 use GpsLab\Component\Payload\Serializer\TypedPayloadNormalizer;
 use GpsLab\Component\Payload\Tests\Fixture\ContactByIdentityQuery;
+use PHPUnit\Framework\TestCase;
 
-class TypedPayloadNormalizerTest extends \PHPUnit_Framework_TestCase
+class TypedPayloadNormalizerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|MessageTypeResolver


### PR DESCRIPTION
# Changed log
- Add `php-7.2` and `php-7.3` tests during Travis CI build.
- To be compatible with future `PHPUnit` versions, using the `PHPUnit\Framework\TestCase` class namesapce instead.
- `satooshi/php-coveralls` package is deprecated and using the `php-coveralls/php-coveralls` instead.
- Removing the `hhvm` version test because it will not be different from future PHP versions.